### PR TITLE
Add Winget Releaser workflow

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,0 +1,13 @@
+name: Publish to WinGet
+on:
+  release:
+    types: [released]
+
+jobs:
+  publish:
+    runs-on: windows-latest
+    steps:
+      - uses: vedantmgoyal2009/winget-releaser@latest
+        with:
+          identifier: VladimirYakovlev.ElectronMail
+          token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
This action automatically generates manifests for WinGet Community Repository ([microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs)) and submits them.

I have already created a PR to add [ElectronMail](https://github.com/microsoft/winget-pkgs/pull/68364) to Winget; this workflow will be used to update it.

Before merging this:
1. Add a PAT with `public_repo` scope as a repository secret named `WINGET_TOKEN` (or rename the secret name in the workflow).

![example](https://user-images.githubusercontent.com/56180050/180631504-f19d12cc-19ce-4991-a753-d4f7ff0adbca.png)



2. Fork https://github.com/microsoft/winget-pkgs under @vladimiry. The action will use that fork for making a branch and creating a PR with the upstream [winget-pkgs](https://github.com/microsoft/winget-pkgs) repository on every release.
3. Sign the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs) for winget-pkgs as you (the PAT owner) will be a first-time contributor.

If you would like to read about this action further, the documentation is [here](https://bittu.eu.org/docs/wr-intro), and the source code is [here](https://github.com/vedantmgoyal2009/winget-releaser).

If you want to see an example of a PR created using this action, see [microsoft/winget-pkgs/pulls (Pull request has been automatically created using 🛫 WinGet Releaser)](https://github.com/microsoft/winget-pkgs/pulls?q=is%3Apr+sort%3Aupdated-desc+Pull+request+has+been+automatically+created+using+%F0%9F%9B%AB+WinGet+Releaser).