### PR TITLE
Add Winget badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Some package types are available for installing from the repositories (`AUR/Pacm
 [![Flathub version](https://img.shields.io/flathub/v/com.github.vladimiry.ElectronMail?label=Flathub)](https://flathub.org/apps/details/com.github.vladimiry.ElectronMail)
 [![MPR version](https://repology.org/badge/latest-versions/electronmail.svg?header=MPR)](https://mpr.makedeb.org/packages/electronmail-bin)
 [![Chocolatey version](https://img.shields.io/chocolatey/v/electron-mail?label=Chocolatey)](https://community.chocolatey.org/packages/electron-mail)
+![Winget version](https://img.shields.io/badge/dynamic/xml?label=Winget&prefix=v&query=%2F%2Ftr%5B%40id%3D%27winget%27%5D%2Ftd%5B3%5D%2Fspan%2Fa&url=https%3A%2F%2Frepology.org%2Fproject%2Felectronmail%2Fversions)
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Some package types are available for installing from the repositories (`AUR/Pacm
 [![Flathub version](https://img.shields.io/flathub/v/com.github.vladimiry.ElectronMail?label=Flathub)](https://flathub.org/apps/details/com.github.vladimiry.ElectronMail)
 [![MPR version](https://repology.org/badge/latest-versions/electronmail.svg?header=MPR)](https://mpr.makedeb.org/packages/electronmail-bin)
 [![Chocolatey version](https://img.shields.io/chocolatey/v/electron-mail?label=Chocolatey)](https://community.chocolatey.org/packages/electron-mail)
-![Winget version](https://img.shields.io/badge/dynamic/xml?label=Winget&prefix=v&query=%2F%2Ftr%5B%40id%3D%27winget%27%5D%2Ftd%5B3%5D%2Fspan%2Fa&url=https%3A%2F%2Frepology.org%2Fproject%2Felectronmail%2Fversions)
+[![Winget version](https://img.shields.io/badge/dynamic/xml?label=Winget&prefix=v&query=%2F%2Ftr%5B%40id%3D%27winget%27%5D%2Ftd%5B3%5D%2Fspan%2Fa&url=https%3A%2F%2Frepology.org%2Fproject%2Felectronmail%2Fversions)](https://github.com/microsoft/winget-pkgs/tree/master/manifests/v/VladimirYakovlev/ElectronMail)
 
 ## Features
 


### PR DESCRIPTION
Add Winget badge in README. I used a custom query to https://repology.org/project/electronmail/versions since shields.io doesn't support Winget badges yet. (https://github.com/badges/shields/issues/5548)