### PR TITLE
Added a GenericName prop. for .deskop entries on Linux

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -48,6 +48,7 @@ linux:
   packageCategory: Office
   desktop:
     StartupWMClass: electron-mail
+    GenericName: Unofficial ProtonMail Desktop App
   executableArgs:
     - '--js-flags="--max-old-space-size=12288"'
 


### PR DESCRIPTION
Searching for "protonmail" / "proton" in rofi and other xdg launchers doesn't bring up ElectronMail.
There is no genericName property available on electron-builder (https://www.electron.build/app-builder-lib.interface.linuxtargetspecificoptions), so I've added one to desktop instead.